### PR TITLE
Problem: Repetitive clone and extend boilerplate when emitting events.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ logTelemetry.log('info', 'hello info level');
 logTelemetry.log('warn', 'hello warn level');
 logTelemetry.log('error', 'hello error with custom data', {custom: 'data'});
 
+var _commonEventData = {
+    method: "readme"
+};
+logTelemetry.log("info",
+{
+    custom: "data with no message and no common event data attached"
+});
+logTelemetry.log("info", _commonEventData,
+{
+    custom: "data with common event data attached"
+});
+logTelemetry.log("info", "my message", _commonEventData,
+{
+    custom: "data with message and common event data attached"
+});
+
 ```
 
 ## Tests
@@ -66,7 +82,7 @@ logTelemetry.log('error', 'hello error with custom data', {custom: 'data'});
 **Public API**
 
   * [new LogTelemetryEvents(config)](#new-logtelemetryeventsconfig)
-  * [telemetry.log(level, \[message\], \[custom\])](#telemetryloglevel-message-custom)
+  * [telemetry.log(level, \[message\], \[common\], \[custom\])](#telemetryloglevel-message-common-custom)
 
 ### new LogTelemetryEvents(config)
 
@@ -76,10 +92,11 @@ logTelemetry.log('error', 'hello error with custom data', {custom: 'data'});
 
 Creates a new LogTelemetryEvents instance.
 
-### telemetry.log(level, [message], [custom])
+### telemetry.log(level, [message], [common], [custom])
 
   * `level`: _String_ Log level to be used for `event.level` property.
   * `message`: _String_ _(Default: undefined)_ An optional message to be used for `event.message` property.
+  * `common`: _Object_ _(Default: undefined)_ Optional common event data to clone and extend with the `event` data.
   * `custom`: _Object_ _(Default: undefined)_ Optional object with custom properties to add to the event.
   * Return: _Object_ The event.
 

--- a/examples/readme.js
+++ b/examples/readme.js
@@ -4,7 +4,7 @@ readme.js: example from the README
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Tristan Slominski, Leora Pearson
+Copyright (c) 2014-2015 Tristan Slominski, Leora Pearson
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -49,3 +49,19 @@ emitter.on('telemetry', function (event) {
 logTelemetry.log('info', 'hello info level');
 logTelemetry.log('warn', 'hello warn level');
 logTelemetry.log('error', 'hello error with custom data', {custom: 'data'});
+
+var _commonEventData = {
+    method: "readme"
+};
+logTelemetry.log("info",
+{
+    custom: "data with no message and no common event data attached"
+});
+logTelemetry.log("info", _commonEventData,
+{
+    custom: "data with common event data attached"
+});
+logTelemetry.log("info", "my message", _commonEventData,
+{
+    custom: "data with message and common event data attached"
+});

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ index.js: telemetry-events-log
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Tristan Slominski, Leora Pearson
+Copyright (c) 2014-2015 Tristan Slominski, Leora Pearson
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -54,30 +54,46 @@ function LogTelemetryEvents(config) {
 
 /*
   * `level`: _String_ Log level to be used for `event.level` property.
-  * `message`: _String_ _(Default: undefined)_ An optional message to be used for `event.message` property.
-  * `custom`: _Object_ _(Default: undefined)_ Optional object with custom properties to add to the event.
+  * `message`: _String_ _(Default: undefined)_ An optional message to be used
+      for `event.message` property.
+  * `common`: _Object_ _(Default: undefined)_ Optional common event data to
+      clone and extend with the `event` data.
+  * `custom`: _Object_ _(Default: undefined)_ Optional object with custom
+      properties to add to the event.
   * Return: _Object_ The event.
 */
-LogTelemetryEvents.prototype.log = function log(level, message, custom) {
+LogTelemetryEvents.prototype.log = function log(level, message, common, custom) {
     var self = this;
 
     var event = {
         type: 'log',
         level: level,
     };
-    // allow custom to be passed as second parameter
-    if (message && typeof message != "string") {
-        custom = message;
-        message = null;
+    if (message && typeof message != "string") // log(level, common, custom)
+    {
+        custom = common;
+        common = message;
+        message = undefined;
     }
-    if (message) {
+    if (!custom) // log(level, custom)
+    {
+        custom = common;
+        common = undefined;
+    }
+    if (message)
+    {
         event.message = message;
     }
-    if (custom) {
-        Object.keys(custom).forEach(function(property) {
+    if (custom)
+    {
+        Object.keys(custom).forEach(function(property)
+        {
             event[property] = custom[property];
         });
     }
-
+    if (common)
+    {
+        return self._telemetry.emit(common, event);
+    }
     return self._telemetry.emit(event);
 };

--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
   },
   "main": "index.js",
   "devDependencies": {
+    "clone": "1.0.2",
     "nodeunit": "0.9.x"
   },
   "dependencies": {
-    "telemetry-events": "0.5.0"
+    "telemetry-events": "1.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Solution: Build-in passing common event data to underlying telemetry-events.

Context: This is the same issue as with https://github.com/tristanls/telemetry-events/pull/2
