### PR TITLE
Prob: When common data is passed in as custom data, it is modified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,22 +50,22 @@ emitter.on('telemetry', function (event) {
 
 logTelemetry.log('info', 'hello info level');
 logTelemetry.log('warn', 'hello warn level');
-logTelemetry.log('error', 'hello error with custom data', {custom: 'data'});
+logTelemetry.log('error', 'hello error with common data', {common: 'data'});
 
 var _commonEventData = {
     method: "readme"
 };
 logTelemetry.log("info",
 {
-    custom: "data with no message and no common event data attached"
+    common: "data with no message and no custom event data attached"
 });
 logTelemetry.log("info", _commonEventData,
 {
-    custom: "data with common event data attached"
+    custom: "data with common and custom event data attached"
 });
 logTelemetry.log("info", "my message", _commonEventData,
 {
-    custom: "data with message and common event data attached"
+    custom: "data with message and common and custom event data attached"
 });
 
 ```

--- a/examples/readme.js
+++ b/examples/readme.js
@@ -4,7 +4,7 @@ readme.js: example from the README
 
 The MIT License (MIT)
 
-Copyright (c) 2014-2015 Tristan Slominski, Leora Pearson
+Copyright (c) 2014-2017 Tristan Slominski, Leora Pearson
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -48,20 +48,20 @@ emitter.on('telemetry', function (event) {
 
 logTelemetry.log('info', 'hello info level');
 logTelemetry.log('warn', 'hello warn level');
-logTelemetry.log('error', 'hello error with custom data', {custom: 'data'});
+logTelemetry.log('error', 'hello error with common data', {common: 'data'});
 
 var _commonEventData = {
     method: "readme"
 };
 logTelemetry.log("info",
 {
-    custom: "data with no message and no common event data attached"
+    common: "data with no message and no custom event data attached"
 });
 logTelemetry.log("info", _commonEventData,
 {
-    custom: "data with common event data attached"
+    custom: "data with common and custom event data attached"
 });
 logTelemetry.log("info", "my message", _commonEventData,
 {
-    custom: "data with message and common event data attached"
+    custom: "data with message and common and custom event data attached"
 });

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ index.js: telemetry-events-log
 
 The MIT License (MIT)
 
-Copyright (c) 2014-2015 Tristan Slominski, Leora Pearson
+Copyright (c) 2014-2017 Tristan Slominski, Leora Pearson
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -74,11 +74,6 @@ LogTelemetryEvents.prototype.log = function log(level, message, common, custom) 
         custom = common;
         common = message;
         message = undefined;
-    }
-    if (!custom) // log(level, custom)
-    {
-        custom = common;
-        common = undefined;
     }
     if (message)
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telemetry-events-log",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Helper for creating and emitting telemetry log events.",
   "scripts": {
     "inject-examples": "node scripts/injectExamples.js",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "main": "index.js",
   "devDependencies": {
-    "clone": "2.0.0",
-    "nodeunit": "0.10.2"
+    "clone": "2.1.1",
+    "nodeunit": "0.11.2"
   },
   "dependencies": {
     "telemetry-events": "1.1.0"


### PR DESCRIPTION
Solv: The use case of `log(level, message, custom)` hardly ever occurs. The much more likely use case is `log(level, message, common)`. However, when this usage occurs, the common object is mutated (for example, the `provenance` chain gets longer and longer with every call to `log()`). This API update accommodates the more likely use case of `log(level, message, common)` without mutating the common object. The use case of `log(level, message, custom)`, where it is expected that custom will not be cloned (i.e. `custom` will be mutated), is no longer supported.

This is an API breaking change, hence MAJOR version bump.